### PR TITLE
Menu::make method and public getItems for faster prototyping menus and micro menus rendering.

### DIFF
--- a/src/Models/MenuGenerator.php
+++ b/src/Models/MenuGenerator.php
@@ -261,6 +261,16 @@ class MenuGenerator implements Countable
     }
 
     /**
+     * Returns an array of menu items to be used without render.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getItems(): \Illuminate\Support\Collection
+    {
+        return $this->items;
+    }
+
+    /**
      * Create new menu with dropdown.
      *
      * @param callable    $callback

--- a/src/Models/MenuGenerator.php
+++ b/src/Models/MenuGenerator.php
@@ -265,7 +265,7 @@ class MenuGenerator implements Countable
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getItems(): \Illuminate\Support\Collection
+    public function getItems(): Collection
     {
         return $this->items;
     }

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -136,10 +136,10 @@ class MenuManager implements Countable
 
                 $params ? $callback($instance, ...$params) : $callback($instance);
             });
-            
+
             return $instance->setBindings($bindings);
         }
-        
+
         return null;
     }
 
@@ -158,11 +158,11 @@ class MenuManager implements Countable
         if ($this->has($name)) {
             $instance = $this->make($name, $presenter, $bindings, $specialSidebar);
             if ($instance) {
-                
+
                 return $instance->render($presenter, $specialSidebar);
             }
         }
-        
+
         return null;
     }
 

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -158,7 +158,6 @@ class MenuManager implements Countable
         if ($this->has($name)) {
             $instance = $this->make($name, $presenter, $bindings, $specialSidebar);
             if ($instance) {
-
                 return $instance->render($presenter, $specialSidebar);
             }
         }

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -110,16 +110,16 @@ class MenuManager implements Countable
     }
 
     /**
-     * Render the menu tag by given name.
+     * Initializes the menu tag by given name without rendering.
      *
      * @param string $name
      * @param string $presenter
      * @param array  $bindings
      * @param bool   $specialSidebar
      *
-     * @return string|null
+     * @return MenuGenerator|null
      */
-    public function render(string $name, string $presenter = null, array $bindings = [], bool $specialSidebar = false): ?string
+    public function make(string $name, string $presenter = null, array $bindings = [], bool $specialSidebar = false): ?MenuGenerator
     {
         if ($this->has($name)) {
             $instance = $this->instance($name);
@@ -136,10 +136,32 @@ class MenuManager implements Countable
 
                 $params ? $callback($instance, ...$params) : $callback($instance);
             });
-
-            return $instance->setBindings($bindings)->render($presenter, $specialSidebar);
+            
+            return $instance->setBindings($bindings);
         }
 
+        return null;
+    }
+    
+    /**
+     * Render the menu tag by given name.
+     *
+     * @param string $name
+     * @param string $presenter
+     * @param array  $bindings
+     * @param bool   $specialSidebar
+     *
+     * @return string|null
+     */
+    public function render(string $name, string $presenter = null, array $bindings = [], bool $specialSidebar = false): ?string
+    {
+        if ($this->has($name)) {
+            $instance = $this->make($name, $presenter, $bindings, $specialSidebar);
+            
+            if ($instance) {
+                return $instance->render($presenter, $specialSidebar);
+            }
+        }
         return null;
     }
 

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -140,7 +140,7 @@ class MenuManager implements Countable
         }
         return null;
     }
-    
+
     /**
      * Render the menu tag by given name.
      *

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -136,10 +136,8 @@ class MenuManager implements Countable
 
                 $params ? $callback($instance, ...$params) : $callback($instance);
             });
-            
             return $instance->setBindings($bindings);
         }
-
         return null;
     }
     
@@ -157,7 +155,6 @@ class MenuManager implements Countable
     {
         if ($this->has($name)) {
             $instance = $this->make($name, $presenter, $bindings, $specialSidebar);
-            
             if ($instance) {
                 return $instance->render($presenter, $specialSidebar);
             }

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -136,8 +136,10 @@ class MenuManager implements Countable
 
                 $params ? $callback($instance, ...$params) : $callback($instance);
             });
+            
             return $instance->setBindings($bindings);
         }
+        
         return null;
     }
 
@@ -156,9 +158,11 @@ class MenuManager implements Countable
         if ($this->has($name)) {
             $instance = $this->make($name, $presenter, $bindings, $specialSidebar);
             if ($instance) {
+                
                 return $instance->render($presenter, $specialSidebar);
             }
         }
+        
         return null;
     }
 

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -113,7 +113,7 @@ class MenuManager implements Countable
      * Initializes the menu tag by given name without rendering.
      *
      * @param string $name
-     * @param string $presenter
+     * @param string|null $presenter
      * @param array  $bindings
      * @param bool   $specialSidebar
      *
@@ -145,7 +145,7 @@ class MenuManager implements Countable
      * Render the menu tag by given name.
      *
      * @param string $name
-     * @param string $presenter
+     * @param string|null $presenter
      * @param array  $bindings
      * @param bool   $specialSidebar
      *

--- a/src/Models/MenuManager.php
+++ b/src/Models/MenuManager.php
@@ -112,10 +112,10 @@ class MenuManager implements Countable
     /**
      * Initializes the menu tag by given name without rendering.
      *
-     * @param string $name
+     * @param string      $name
      * @param string|null $presenter
-     * @param array  $bindings
-     * @param bool   $specialSidebar
+     * @param array       $bindings
+     * @param bool        $specialSidebar
      *
      * @return MenuGenerator|null
      */
@@ -144,10 +144,10 @@ class MenuManager implements Countable
     /**
      * Render the menu tag by given name.
      *
-     * @param string $name
+     * @param string      $name
      * @param string|null $presenter
-     * @param array  $bindings
-     * @param bool   $specialSidebar
+     * @param array       $bindings
+     * @param bool        $specialSidebar
      *
      * @return string|null
      */


### PR DESCRIPTION
Rinvex Menus features are solid: multiple menus, item attributes and properties, nesting and dropdowns, and presenters.

People gets very creative about menus.

In our case we are prototyping menus for a new app and coding presentables is not the right moment yet.
We are using tabler, a derivative from bootstrap 5 with some twists so we cannot use default ones even if blade templates were made for BS5. They are currently made for BS4.
Apart from that we are using TwigBridge.

With this pull developers can make:

```
$menu = \Menu::make('modules');

foreach ($menu.getItems() as $item) {
    ...iterate item.properties.title ...
}
 ```
 
 